### PR TITLE
Implemented atomic leaving of sm

### DIFF
--- a/src/stubs/sm_entry.s
+++ b/src/stubs/sm_entry.s
@@ -113,6 +113,8 @@ __sm_entry:
     clr r15
 
 1:
+    ; atomic leaving
+    dint
     mov r1, &__sm_sp
     mov #0xffff, r6
     br r7

--- a/src/stubs/sm_exit.s
+++ b/src/stubs/sm_exit.s
@@ -33,6 +33,8 @@ __sm_exit:
     jc 1f
     clr r15
 1:
+    ; atomic leaving of sm
+    dint
     ; store sp
     mov r1, &__sm_sp
 
@@ -57,7 +59,9 @@ __reti_entry:
     pop r14
     pop r15
     
-    ; clear bit 0
+    ; clear bit 0 
+    ; maybe we also should store stackpointer
+    ; or we assume: reti never jumps out of sm
     bic #0x1, &__sm_sp
     
     reti

--- a/src/stubs/sm_verify.s
+++ b/src/stubs/sm_verify.s
@@ -12,10 +12,13 @@ __sm_verify:
     jeq .Ltag
 
     ; we have a stored ID, check if it  matches with the SM
+    ; disable interrupt to do this atomically
+    dint
     mov r14, r15
     .word 0x1386
     cmp r12, r15
     jne .Lexit
+    eint
     ret
 
 .Ltag:


### PR DESCRIPTION
Implemented atomic leaving of SMs to handle a few issues regarding interrupting SMs that are preparing to jump to code outside of the sm.