### PR TITLE
Make it possible to compile with newer MSP430-GCC compiler

### DIFF
--- a/cmake/FindMSPGCC.cmake
+++ b/cmake/FindMSPGCC.cmake
@@ -1,10 +1,13 @@
 include(FindPackageHandleStandardArgs)
 
-find_program(MSPGCC_EXECUTABLE msp430-gcc)
+# MSP430_GCC_PREFIX should be one of (msp430, msp430-elf)
+set(MSP430_GCC_PREFIX msp430 CACHE STRING "MSP430 GCC prefix")
+
+find_program(MSPGCC_EXECUTABLE ${MSP430_GCC_PREFIX}-gcc)
 
 get_filename_component(TMP ${MSPGCC_EXECUTABLE} REALPATH)
 get_filename_component(TMP ${TMP} PATH)
-get_filename_component(MSPGCC_BASE_DIR ${TMP}/../msp430 ABSOLUTE)
+get_filename_component(MSPGCC_BASE_DIR ${TMP}/../${MSP430_GCC_PREFIX} ABSOLUTE)
 set(TMP)
 set(MSPGCC_LIB_DIR ${MSPGCC_BASE_DIR}/lib)
 set(MSPGCC_INCLUDE_DIR ${MSPGCC_BASE_DIR}/include)

--- a/cmake/UseMSPGCC.cmake
+++ b/cmake/UseMSPGCC.cmake
@@ -1,4 +1,4 @@
 set(MCU msp430f149)
 set(CMAKE_C_COMPILER ${MSPGCC_EXECUTABLE})
-include_directories (${MSPGCC_INCLUDEDIR})
+include_directories (${MSPGCC_BASE_DIR}/../include)
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -mmcu=${MCU}")

--- a/cmake/UseMSPGCC.cmake
+++ b/cmake/UseMSPGCC.cmake
@@ -1,1 +1,4 @@
+set(MCU msp430f149)
 set(CMAKE_C_COMPILER ${MSPGCC_EXECUTABLE})
+include_directories (${MSPGCC_INCLUDEDIR})
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -mmcu=${MCU}")

--- a/src/llvm/CMakeLists.txt
+++ b/src/llvm/CMakeLists.txt
@@ -9,4 +9,4 @@ set(SRC
 )
 
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
-add_llvm_library(SancusModuleCreator MODULE ${SRC})
+add_llvm_loadable_module(SancusModuleCreator ${SRC})

--- a/src/llvm/CMakeLists.txt
+++ b/src/llvm/CMakeLists.txt
@@ -9,4 +9,4 @@ set(SRC
 )
 
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
-add_llvm_loadable_module(SancusModuleCreator ${SRC})
+add_llvm_library(SancusModuleCreator MODULE ${SRC})

--- a/src/sancus_support/CMakeLists.txt
+++ b/src/sancus_support/CMakeLists.txt
@@ -11,6 +11,10 @@ set(SRC_HOST
     unprotected_entry.s
 )
 
+set_source_files_properties(unprotected_entry.s 
+                            PROPERTIES 
+                            COMPILE_FLAGS "-mmcu=${MCU}")
+
 add_library(sancus-sm-support STATIC ${SRC_SM})
 add_library(sancus-host-support STATIC ${SRC_HOST})
 

--- a/src/sancus_support/sm_support.c
+++ b/src/sancus_support/sm_support.c
@@ -18,7 +18,7 @@ sm_id sancus_enable_wrapped(struct SancusModule* sm, unsigned nonce, void* tag)
           "m"(sm->vendor_id),
           "m"(sm->public_start), "m"(sm->public_end),
           "m"(sm->secret_start), "m"(sm->secret_end)
-        : "r9", "r10", "r11", "r12", "r13", "r14", "r15");
+        : "9", "10", "11", "12", "13", "14", "15");
 
     return sm->id;
 }

--- a/src/sancus_support/sm_support.h
+++ b/src/sancus_support/sm_support.h
@@ -114,6 +114,7 @@ sm_id sancus_enable(struct SancusModule* sm);
  */
 sm_id sancus_enable_wrapped(struct SancusModule* sm, unsigned nonce, void* tag);
 
+#undef always_inline
 #define always_inline static inline __attribute__((always_inline))
 
 /**
@@ -158,7 +159,7 @@ always_inline sm_id sancus_verify_address(const void* expected_tag,
         "mov r15, %0"
         : "=m"(ret)
         : "r"(address), "r"(expected_tag)
-        : "r14", "r15");
+        : "14", "15");
     return ret;
 }
 
@@ -196,7 +197,7 @@ always_inline int sancus_verify_caller(const void* expected_tag)
         "mov r15, %0"
         : "=m"(ret)
         : "r"(expected_tag)
-        : "r15");
+        : "15");
     return ret;
 }
 
@@ -251,7 +252,7 @@ always_inline int sancus_wrap_with_key(const void* key,
           "m"(ad), "m"(ad_end),
           "m"(body), "m"(body_end),
           "m"(cipher), "m"(tag)
-        : "r9", "r10", "r11", "r12", "r13", "r14", "r15");
+        : "9", "10", "11", "12", "13", "14", "15");
 
     return ret;
 }
@@ -299,7 +300,7 @@ always_inline int sancus_unwrap_with_key(const void* key,
           "m"(ad), "m"(ad_end),
           "m"(cipher), "m"(cipher_end),
           "m"(body), "m"(tag)
-        : "r9", "r10", "r11", "r12", "r13", "r14", "r15");
+        : "9", "10", "11", "12", "13", "14", "15");
 
     return ret;
 }
@@ -347,7 +348,7 @@ always_inline sm_id sancus_get_id(void* addr)
         "mov r15, %0"
         : "=m"(ret)
         : "m"(addr)
-        : "r15");
+        : "15");
     return ret;
 }
 
@@ -374,7 +375,7 @@ always_inline sm_id sancus_get_caller_id(void)
         "mov r15, %0"
         : "=m"(ret)
         :
-        : "r15");
+        : "15");
     return ret;
 }
 
@@ -515,7 +516,11 @@ extern char __unprotected_sp;
  * void __attribute__((interrupt(SM_VECTOR))) the_isr(void) {...}
  * @endcode
  */
+#if __GNUC__ < 5
 #define SM_VECTOR 26
+#else
+#define SM_VECTOR 14
+#endif
 
 /**
  * Return value of sancus_get_caller_id() for unprotected code.

--- a/src/sancus_support/sm_support.h
+++ b/src/sancus_support/sm_support.h
@@ -516,10 +516,10 @@ extern char __unprotected_sp;
  * void __attribute__((interrupt(SM_VECTOR))) the_isr(void) {...}
  * @endcode
  */
-#if __GNUC__ < 5
-#define SM_VECTOR 26
-#else
+#if __GNUC__ >= 5
 #define SM_VECTOR 14
+#else
+#define SM_VECTOR 26
 #endif
 
 /**


### PR DESCRIPTION
Running cmake with -DMSP430_GCC_PREFIX=msp430-elf configures the build to use the msp430-elf-gcc compiler. See http://www.ti.com/tool/MSP430-GCC-OPENSOURCE for more info.