### PR TITLE
Balance stack pointer initialization in sm_entry

### DIFF
--- a/src/llvm/SancusModuleCreator.cpp
+++ b/src/llvm/SancusModuleCreator.cpp
@@ -348,7 +348,6 @@ Function* SancusModuleCreator::getStub(Function& caller, Function& callee)
                         "\tbr #" + brName + "\n"
                         "1:\n"
                         "\tmov &__unprotected_sp, r1\n"
-                        "\teint\n"
                         "\tpop r7\n"
                         "\tpop r6\n"
                         "\tret"

--- a/src/stubs/sm_entry.s
+++ b/src/stubs/sm_entry.s
@@ -113,11 +113,8 @@ __sm_entry:
     clr r15
 
 1:
-    ; NOTE: disable interrupts to properly restore the enclave-private stack
-    dint
+    mov r1, &__sm_sp
     mov #0xffff, r6
-    ; interrupts are disabled now (1 cycle after dint)
-    mov #__sm_stack_init, &__sm_sp
     br r7
 
 .Lerror:

--- a/src/stubs/sm_entry.s
+++ b/src/stubs/sm_entry.s
@@ -29,7 +29,7 @@ __sm_entry:
 
     ; === safe to handle IRQs now ===
     eint
-    
+
     jz 1f
     ; restore execution state if the sm was resumed
     br #__reti_entry ; defined in exit.s
@@ -57,7 +57,7 @@ __sm_entry:
     br #__sm_isr
 1:
     pop r15
-    
+
     ; check if this is a return
     cmp #0xffff, r6
     jne 1f
@@ -113,8 +113,8 @@ __sm_entry:
     clr r15
 
 1:
-    mov r1, &__sm_sp
     mov #0xffff, r6
+    mov #0, &__sm_sp
     br r7
 
 .Lerror:

--- a/src/stubs/sm_exit.s
+++ b/src/stubs/sm_exit.s
@@ -56,12 +56,12 @@ __reti_entry:
     pop r13
     pop r14
     pop r15
-    
-    ; clear bit 0
-    bic #0x1, &__sm_sp
-    
+
+    ; clear sp
+    mov #0, &__sm_sp
+
     reti
-        
+
     .align 2
     .global __ret_entry
     .type __ret_entry,@function


### PR DESCRIPTION
As described in https://github.com/jovanbulck/nemesis/pull/2, currently the first call to a protected module adds a 2 cycle delay compared to subsequent calls.

This pull request balances the stack pointer initialization, so that regardless of the call, the code always takes the same time to run.

Running `nemesis/bsl` after the fix:

```
[main.c] Testing balanced BSL for end-to-end execution timing attack...
[main.c] Unbalanced: wrong pwd[0] byte with TSC 614
[main.c] Unbalanced: wrong pwd[0]+[1] bytes with TSC 616
[main.c] --> OK
```
The balancing can also be shown in the traces (top one showing the first call, bottom one a later call):

![GTKWave](https://user-images.githubusercontent.com/1733366/67794714-6989b800-fa7d-11e9-9849-9e250cc932e6.png)

