### PR TITLE
Fixing incorrect indentation in cleanup of temporary files

### DIFF
--- a/src/drivers/common.py
+++ b/src/drivers/common.py
@@ -88,10 +88,10 @@ def cleanup():
     if tmp_files:
         if args.debug:
             debug('Keeping temporary files: ' + ', '.join(tmp_files))
-    else:
-        info('Cleaning up temporary files: ' + ', '.join(tmp_files))
-        rm(*tmp_files)
-        del tmp_files[:]
+        else:
+            info('Cleaning up temporary files: ' + ', '.join(tmp_files))
+            rm(*tmp_files)
+            del tmp_files[:]
 
 
 def call_prog(prog, arguments=[], get_output=False):


### PR DESCRIPTION
The tmp_files are used by the compiler and linker script. Currently, the cleanup script is incorrectly indented and only removes the tmp_files if they do not exist, in contrast to only removing them when not in debug mode (the more idented if statement).