### PR TITLE
Add KEEP construct to SM linking

### DIFF
--- a/src/drivers/linker.py
+++ b/src/drivers/linker.py
@@ -593,6 +593,7 @@ mmio_text_section = '''.text.sm.{0} :
     {2}
     . = ALIGN(2);
     __sm_{0}_public_end = .;
+    KEEP(*(.sm.{0}.*.table))
   }}'''
 
 data_section = '''. = ALIGN(2);


### PR DESCRIPTION
This extends #27 to MMIO enclaves as the same problem occurs there once they are used from libraries.